### PR TITLE
Estimate maximum execution gas price and bounty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.3.tgz",
       "integrity": "sha512-auZ3vEo3UW8tZc9NhF0MTnutKlf+YhsfC3+dwskFcil/EoqqZF60pGuJ2v2Ae1OJTUp3DJnjOJMqrpkmKB904w==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -90,6 +91,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
       "integrity": "sha512-qwQgQqXXTRv2h2AlJef+tMEszLFkCB9dWnrJYIdAwqjubERXEc/geB+S3apRw0yQyTVnsBf8r6BhlrE8vx+3WQ==",
+      "dev": true,
       "requires": {
         "@types/bn.js": "*",
         "@types/node": "*"
@@ -2302,17 +2304,10 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
-        "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-          "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
-          }
-        },
         "ethereumjs-util": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -2466,6 +2461,30 @@
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
           "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
           "dev": true
+        }
+      }
+    },
+    "ethereumjs-abi": {
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^5.0.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
         }
       }
     },
@@ -7772,6 +7791,14 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
@@ -8235,7 +8262,20 @@
           "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.37"
+            "web3-core-helpers": "1.0.0-beta.37",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -8592,7 +8632,20 @@
           "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.37"
+            "web3-core-helpers": "1.0.0-beta.37",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-utils": {
@@ -8735,19 +8788,8 @@
       "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35"
-      },
-      "dependencies": {
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
-        }
+        "web3-core-helpers": "1.0.0-beta.35",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {
@@ -8785,6 +8827,16 @@
           "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "whatwg-fetch": {
@@ -8893,6 +8945,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@types/ethereumjs-util": "5.2.0",
     "@types/chai": "4.1.7",
     "@types/node-fetch": "2.1.4",
     "@types/underscore": "1.8.9",
@@ -50,7 +51,6 @@
   },
   "dependencies": {
     "@ethereum-alarm-clock/contracts": "github:ethereum-alarm-clock/ethereum-alarm-clock#e1b4db61ec43154117be5582bc92dc881dc27ea5",
-    "@types/ethereumjs-util": "5.2.0",
     "bignumber.js": "8.0.1",
     "ethereumjs-util": "6.0.0",
     "moment": "2.23.0",

--- a/src/utils/GasPriceUtil.ts
+++ b/src/utils/GasPriceUtil.ts
@@ -75,7 +75,7 @@ export default class GasPriceUtil {
   }
 
   private async externalApiGasPrice(): Promise<GasPriceEstimation> {
-    const networkId: string = (await this.web3.eth.net.getId()).toString();
+    const networkId = await this.web3.eth.net.getId();
     const services = GAS_PRICE_FETCHING_SERVICES[networkId];
 
     if (!services) {

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -159,6 +159,25 @@ export default class Util {
       .decimalPlaces(0);
   }
 
+  public static estimateBountyForExecutionGasPrice(
+    gasPrice: BigNumber,
+    callGas: BigNumber,
+    additionalGasPrice: BigNumber
+  ) {
+    const arbitraryCoefficient = 0.85;
+    const paymentModifier = 0.9;
+    const claimingGasAmount = 100000;
+    const claimingGasCost = gasPrice.times(claimingGasAmount);
+    const executionGasAmount = callGas.plus(EXECUTION_OVERHEAD);
+
+    return additionalGasPrice
+      .times(executionGasAmount)
+      .plus(claimingGasCost)
+      .dividedBy(paymentModifier)
+      .dividedBy(arbitraryCoefficient)
+      .decimalPlaces(0);
+  }
+
   private web3: Web3;
 
   constructor(web3: Web3) {

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -71,6 +71,8 @@ const NETWORK_TO_ADDRESSES_MAPPING = {
   1002: AddressesJSONTest
 };
 
+const EXECUTION_OVERHEAD = 180000;
+
 export default class Util {
   public static getWeb3FromProviderUrl(providerUrl: string): Web3 {
     let provider: Provider;
@@ -134,8 +136,27 @@ export default class Util {
     return bountyBN
       .plus(feeBN)
       .plus(callGasBN.times(gasPrice))
-      .plus(gasPriceBN.times(180000))
+      .plus(gasPriceBN.times(EXECUTION_OVERHEAD))
       .plus(callValueBN);
+  }
+
+  public static estimateMaximumExecutionGasPrice(
+    bounty: BigNumber,
+    gasPrice: BigNumber,
+    callGas: BigNumber
+  ) {
+    const arbitraryCoefficient = 0.85;
+    const paymentModifier = 0.9;
+    const claimingGasAmount = 100000;
+    const claimingGasCost = gasPrice.times(claimingGasAmount);
+    const executionGasAmount = callGas.plus(EXECUTION_OVERHEAD);
+
+    return bounty
+      .times(paymentModifier)
+      .minus(claimingGasCost)
+      .dividedBy(executionGasAmount)
+      .times(arbitraryCoefficient)
+      .decimalPlaces(0);
   }
 
   private web3: Web3;

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -145,6 +145,14 @@ export default class Util {
     gasPrice: BigNumber,
     callGas: BigNumber
   ) {
+    if (!gasPrice || !callGas || !bounty) {
+      throw new Error('Missing arguments');
+    }
+
+    if (gasPrice.isNegative() || callGas.isNegative() || bounty.isNegative()) {
+      throw new Error('gasPrice, callGas and bounty has to be positive number');
+    }
+
     const arbitraryCoefficient = 0.85;
     const paymentModifier = 0.9;
     const claimingGasAmount = 100000;
@@ -164,6 +172,14 @@ export default class Util {
     callGas: BigNumber,
     additionalGasPrice: BigNumber
   ) {
+    if (!gasPrice || !callGas || !additionalGasPrice) {
+      throw new Error('Missing arguments');
+    }
+
+    if (gasPrice.isNegative() || callGas.isNegative() || additionalGasPrice.isNegative()) {
+      throw new Error('gasPrice, callGas and additionalGasPrice has to be positive number');
+    }
+
     const arbitraryCoefficient = 0.85;
     const paymentModifier = 0.9;
     const claimingGasAmount = 100000;

--- a/tests/unit/UnitTestUtil.ts
+++ b/tests/unit/UnitTestUtil.ts
@@ -39,7 +39,7 @@ describe('Util Unit Tests', async () => {
   });
 
   describe('estimateMaximumExecutionGasPrice()', () => {
-    it('estimates gasPrice > current gas price when bounty is higher than costs', () => {
+    it('estimated gasPrice > current gas price when bounty is higher than costs', () => {
       const bounty = new BigNumber(web3.utils.toWei('0.02', 'ether'));
       const gasPrice = new BigNumber(web3.utils.toWei('2', 'gwei'));
       const callGas = new BigNumber(21000);
@@ -47,6 +47,29 @@ describe('Util Unit Tests', async () => {
       const estimation = Util.estimateMaximumExecutionGasPrice(bounty, gasPrice, callGas);
 
       assert.isTrue(estimation.isGreaterThan(gasPrice));
+    });
+  });
+
+  describe('estimateBountyForExecutionGasPrice()', () => {
+    it('for 0 additional gasPrice the bounty equals the costs', () => {
+      const arbitraryCoefficient = 0.85;
+      const paymentModifier = 0.9;
+
+      const gasPrice = new BigNumber(web3.utils.toWei('2', 'gwei'));
+      const additionalGasPrice = new BigNumber(0);
+      const callGas = new BigNumber(21000);
+      const claimingGasAmount = 100000;
+      const claimingCost = gasPrice.multipliedBy(claimingGasAmount);
+      const executionOverhead = new BigNumber(180000);
+
+      const expectedBounty = claimingCost
+        .dividedBy(paymentModifier)
+        .dividedBy(arbitraryCoefficient)
+        .decimalPlaces(0);
+
+      const bounty = Util.estimateBountyForExecutionGasPrice(gasPrice, callGas, additionalGasPrice);
+
+      assert.isTrue(expectedBounty.isEqualTo(bounty));
     });
   });
 });

--- a/tests/unit/UnitTestUtil.ts
+++ b/tests/unit/UnitTestUtil.ts
@@ -1,6 +1,7 @@
 import { expect, assert } from 'chai';
 import { Util } from '../../src';
 import { providerUrl } from '../helpers';
+import BigNumber from 'bignumber.js';
 
 describe('Util Unit Tests', async () => {
   const web3 = Util.getWeb3FromProviderUrl(providerUrl);
@@ -34,6 +35,18 @@ describe('Util Unit Tests', async () => {
     it('returns true when watching', async () => {
       const watching = await Util.isWatchingEnabled(web3);
       assert.isTrue(watching);
+    });
+  });
+
+  describe('estimateMaximumExecutionGasPrice()', () => {
+    it('estimates gasPrice > current gas price when bounty is higher than costs', () => {
+      const bounty = new BigNumber(web3.utils.toWei('0.02', 'ether'));
+      const gasPrice = new BigNumber(web3.utils.toWei('2', 'gwei'));
+      const callGas = new BigNumber(21000);
+
+      const estimation = Util.estimateMaximumExecutionGasPrice(bounty, gasPrice, callGas);
+
+      assert.isTrue(estimation.isGreaterThan(gasPrice));
     });
   });
 });


### PR DESCRIPTION
1. estimateMaximumExecutionGasPrice

Helper function to calculate the maximum possible gas price at the time of the execution. Estimation should help users to pick the right amount of bounty for the scheduled transaction.

Estimation assumes: 
- `paymentModifier` 0.9 (maximum payment modifier picked by TimeNode)
- `arbitraryCoefficient` 0.85 (total uncertainty coefficient) 

The formula is as follows:

```
maxGasPrice = 
       bounty
      .times(paymentModifier)
      .minus(claimingGasCost)
      .dividedBy(executionGasAmount)
      .times(arbitraryCoefficient)
      .decimalPlaces(0);
```

Example estimation:

`bounty` = 0.02 ETH
`callGas` = 20000
`gasPrice` = 3 GWei

`estimatedMaxGasPrice` = 75.2 GWei

2. estimateBountyForExecutionGasPrice

Similar to `estimateMaximumExecutionGasPrice` but accepts `additionalGasPrice` as an argument.

The formula is as follows:
```
bounty = 
      additionalGasPrice
      .times(executionGasAmount)
      .plus(claimingGasCost)
      .dividedBy(paymentModifier)
      .dividedBy(arbitraryCoefficient)
      .decimalPlaces(0);
```
Examples:

Current gasPrice is 2Gwei, when user want trasaction to be  executed up to 10GWei gasPrice the wallet should:

`estimateMaximumExecutionGasPrice(2Gwei, callGas, 8Gwei)` (8Gwei + 2GWei = 10GWei)

**The callGasPrice in the contract deployemnt should be set to 2Gwei.** as additional gas up to 10Gwei will be covered by the `bounty`